### PR TITLE
Ignore keypress events when source is an input field.

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -162,6 +162,10 @@ PrivateMessages.prototype.onClick = function (evt) {
 
 function LocaleOverride() {
     $(window).keypress(function (evt) {
+        if ($(evt.target).is('input')) {
+            return;
+        }
+
         if (evt.which == 108) { // 'l'
             var pref = window.prompt("Enter your preferred language (ISO-639-1, thanks)");
 


### PR DESCRIPTION
This will let you search for something containing 'L' without having to frob a language prompt.
